### PR TITLE
addKeyBoardToDOM method as separated method

### DIFF
--- a/dist/Keyboard.js
+++ b/dist/Keyboard.js
@@ -79,7 +79,8 @@ var _class = function (_React$Component) {
             }
 
             //Add jQuery Keyboard to DOM Element
-            (0, _jquery2.default)(_reactDom2.default.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
+            // (0, _jquery2.default)(_reactDom2.default.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
+            this.addKeyBoardToDOM();
 
             // Update while typing if usePreview is false
             if (this.props.options.usePreview === false) {
@@ -89,6 +90,11 @@ var _class = function (_React$Component) {
             }
         }
     }, {
+        key: 'addKeyBoardToDOM',
+        value: function addKeyBoardToDOM() {
+            (0, _jquery2.default)(_reactDom2.default.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
+        }
+    },{
         key: 'clear',
         value: function clear() {
             this.setState({ value: '' });

--- a/lib/Keyboard.js
+++ b/lib/Keyboard.js
@@ -10,6 +10,11 @@ export default class extends React.Component {
         this.state = { value: "", className: 'keyboard-wrapper' };
         this.handleChange = this.handleChange.bind(this);
     }
+    
+    addKeyboardElementToDom = () => {
+        jQuery(ReactDOM.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
+    }
+    
     componentDidMount() {
         // Set Value to Input Element on Accept
         this.setState({ value: this.props.value });
@@ -39,8 +44,9 @@ export default class extends React.Component {
             }.bind(this);
         }
 
-        //Add jQuery Keyboard to DOM Element
-        jQuery(ReactDOM.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
+        // Add jQuery Keyboard to DOM Element
+        // jQuery(ReactDOM.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
+        this.addKeyboardElementToDom();
         
         // Update while typing if usePreview is false
         if (this.props.options.usePreview === false) {

--- a/lib/Keyboard.js
+++ b/lib/Keyboard.js
@@ -11,10 +11,6 @@ export default class extends React.Component {
         this.handleChange = this.handleChange.bind(this);
     }
     
-    addKeyboardElementToDom = () => {
-        jQuery(ReactDOM.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
-    }
-    
     componentDidMount() {
         // Set Value to Input Element on Accept
         this.setState({ value: this.props.value });
@@ -46,7 +42,7 @@ export default class extends React.Component {
 
         // Add jQuery Keyboard to DOM Element
         // jQuery(ReactDOM.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
-        this.addKeyboardElementToDom();
+        this.addKeyBoardToDOM();
         
         // Update while typing if usePreview is false
         if (this.props.options.usePreview === false) {
@@ -54,6 +50,9 @@ export default class extends React.Component {
                 this.handleChange(null, keyboard.preview.value);
             }.bind(this));
         }
+    }
+    addKeyBoardToDOM() {
+        jQuery(ReactDOM.findDOMNode(this.refs.keyboard)).keyboard(this.props.options);
     }
     clear() {
         this.setState({ value: '' });


### PR DESCRIPTION
I need to use navigation extension  https://mottie.github.io/Keyboard/docs/navigate.html

So I need to use this code `$('#keyboard').keyboard(options1).addNavigation(options2)
instead of `$('#keyboard').keyboard(options1)`.
 
Then I will change the separated method to add extensions:
`Keyboard.prototype.addKeyBoardToDOM = myMethod;`