### PR TITLE
Updated example layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ import Keyboard from 'react-virtual-keyboard';
   name='keyboard'
   options={{
     type:"input",
-    layout: "querty",
+    layout: "qwerty",
     alwaysOpen: true,
     usePreview: false,
     useWheel: false,


### PR DESCRIPTION
Changed layout from "querty" to "qwerty" as described by https://github.com/Utzel-Butzel/react-virtual-keyboard/issues/11